### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ starknet_specVersion
 
 Write methods are not yet supported.
 
-<a href="https://glama.ai/mcp/servers/kfj96s92mg"><img width="380" height="200" src="https://glama.ai/mcp/servers/kfj96s92mg/badge" alt="Starknet Server MCP server" /></a>
+<a href="https://glama.ai/mcp/servers/kfj96s92mg"><img width="380" height="200" src="https://glama.ai/mcp/servers/kfj96s92mg/badge" alt="Starknet Server MCP" /></a>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ starknet_specVersion
 
 Write methods are not yet supported.
 
+<a href="https://glama.ai/mcp/servers/kfj96s92mg"><img width="380" height="200" src="https://glama.ai/mcp/servers/kfj96s92mg/badge" alt="Starknet Server MCP server" /></a>
+
 ## Installation
 
 Install [Bun](https://bun.sh/). Clone this repo. Install the dependencies with `bun install`. Update Claude's MCP config - see [instructions](https://modelcontextprotocol.io/quickstart/user) for your particular OS. You'll want something like this in the `claude_desktop_config.json` file:


### PR DESCRIPTION
This PR adds a badge for the [Starknet MCP Server](https://glama.ai/mcp/servers/kfj96s92mg) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/kfj96s92mg"><img width="380" height="200" src="https://glama.ai/mcp/servers/kfj96s92mg/badge" alt="Starknet Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.